### PR TITLE
Precompiled headers, and some minor other makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,16 @@ LDFLAGS := $(CMDSTAN)/stan/lib/stan_math/lib/tbb/libtbb.so.2 -Wl,-rpath,$(CMDSTA
 all: build/prototype
 
 clean:
-	rm -f build/prototype build/mean_model.hpp
+	rm -f build/prototype build/mean_model.hpp build/mean_model.hpp.gch
 
 build/mean_model.hpp: models/mean_model.stan | build
 	$(CMDSTAN)/bin/stanc $< --o $@
 
-build/prototype: prototype.cpp build/mean_model.hpp
-	g++ $(CXXFLAGS) $< -o $@ $(LDFLAGS)
+build/mean_model.hpp.gch: build/mean_model.hpp
+	g++ $(CXXFLAGS) $< -o $@
+
+build/prototype: prototype.cpp build/mean_model.hpp.gch
+	g++ $(CXXFLAGS) $< -o $@ $(LDFLAGS) -Winvalid-pch
 
 build:
 	mkdir build

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ CMDSTAN := /home/gertjan/Documents/Thesis/cmdstan-2.33.1
 
 CXXFLAGS := -I $(CMDSTAN)/stan/src
 CXXFLAGS += -I $(CMDSTAN)/stan/lib/rapidjson_1.1.0
-CXXFLAGS += -I $(CMDSTAN)/stan/lib/stan_math
-CXXFLAGS += -I $(CMDSTAN)/stan/lib/stan_math/lib/eigen_3.4.0 
+CXXFLAGS += -isystem $(CMDSTAN)/stan/lib/stan_math
+CXXFLAGS += -isystem $(CMDSTAN)/stan/lib/stan_math/lib/eigen_3.4.0
 CXXFLAGS += -I $(CMDSTAN)/stan/lib/stan_math/lib/tbb
 CXXFLAGS += -I $(CMDSTAN)/stan/lib/stan_math/lib/tbb_2020.3/include
 CXXFLAGS += -I $(CMDSTAN)/stan/lib/stan_math/lib/sundials_6.1.1/include

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ CXXFLAGS += -I $(CMDSTAN)/stan/lib/stan_math/lib/sundials_6.1.1/include
 CXXFLAGS += -I $(CMDSTAN)/stan/lib/stan_math/lib/boost_1.78.0
 CXXFLAGS += -D_REENTRANT -DBOOST_DISABLE_ASSERTS
 
+MODEL_NAME := mean_model
+
 DEBUG ?= 0
 ifeq ($(DEBUG), 1)
 	CXXFLAGS += -g -O0
@@ -22,15 +24,15 @@ LDFLAGS := $(CMDSTAN)/stan/lib/stan_math/lib/tbb/libtbb.so.2 -Wl,-rpath,$(CMDSTA
 all: build/prototype
 
 clean:
-	rm -f build/prototype build/mean_model.hpp build/mean_model.hpp.gch
+	rm -f build/prototype build/*.hpp build/*.hpp.gch
 
-build/mean_model.hpp: models/mean_model.stan | build
+build/$(MODEL_NAME).hpp: models/$(MODEL_NAME).stan | build
 	$(CMDSTAN)/bin/stanc $< --o $@
 
-build/mean_model.hpp.gch: build/mean_model.hpp
+build/$(MODEL_NAME).hpp.gch: build/$(MODEL_NAME).hpp
 	g++ $(CXXFLAGS) $< -o $@
 
-build/prototype: prototype.cpp build/mean_model.hpp.gch
+build/prototype: prototype.cpp build/$(MODEL_NAME).hpp.gch
 	g++ $(CXXFLAGS) $< -o $@ $(LDFLAGS) -Winvalid-pch
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,11 @@ all: build/prototype
 clean:
 	rm -f build/prototype build/mean_model.hpp
 
-build/mean_model.hpp: models/mean_model.stan
+build/mean_model.hpp: models/mean_model.stan | build
 	$(CMDSTAN)/bin/stanc $< --o $@
 
 build/prototype: prototype.cpp build/mean_model.hpp
 	g++ $(CXXFLAGS) $< -o $@ $(LDFLAGS)
+
+build:
+	mkdir build

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ LDFLAGS := $(CMDSTAN)/stan/lib/stan_math/lib/tbb/libtbb.so.2 -Wl,-rpath,$(CMDSTA
 
 .PHONY: all clean
 
-all: prototype
+all: build/prototype
 
 clean:
 	rm -f build/prototype build/mean_model.hpp
 
-mean_model.hpp: models/mean_model.stan
-	$(CMDSTAN)/bin/stanc $< --o build/mean_model.hpp
+build/mean_model.hpp: models/mean_model.stan
+	$(CMDSTAN)/bin/stanc $< --o $@
 
-prototype: prototype.cpp mean_model.hpp
-	g++ $(CXXFLAGS) $< -o build/$@ $(LDFLAGS)
+build/prototype: prototype.cpp build/mean_model.hpp
+	g++ $(CXXFLAGS) $< -o $@ $(LDFLAGS)

--- a/prototype.cpp
+++ b/prototype.cpp
@@ -1,5 +1,8 @@
-//#include <stan/model/model_header.hpp>
+// Note: the model.hpp needs to be the first include, so that it can be a
+// precompiled header.
 #include "build/mean_model.hpp"
+
+//#include <stan/model/model_header.hpp>
 #include <stan/io/empty_var_context.hpp>
 #include <stan/io/json/json_data.hpp>
 namespace mm = mean_model_model_namespace;


### PR DESCRIPTION
This changes the makefile to use a precompiled header for the model. On my machine, compiling prototype.cpp with the model as a precompiled header takes ~6.2 seconds, while doing the same with _all_ included headers results in a compilation time of ~5.8 seconds. I thought this was not worth the additional hassle.

Be sure to look at the commit descriptions for a little additional information on the changes. I tried to make the commits sensible change units.